### PR TITLE
SLURM changes

### DIFF
--- a/plmnist/tune/trainable.py
+++ b/plmnist/tune/trainable.py
@@ -81,3 +81,7 @@ class MNISTTrainable(Trainable):
 
         # make sure to set `resume_ckpt_path` so the next step will load the weights from the given checkpoint
         self.resume_ckpt_path = checkpoint["model_path"]
+
+    # add a resource request for GPU training. this is low-memory, so 8 can easily fit on one GPU.
+    def default_resource_request(self):
+        return {"cpu": 1, "gpu": 0.125}

--- a/plmnist/tune/utils.py
+++ b/plmnist/tune/utils.py
@@ -3,6 +3,11 @@ def hide_logs():
 
     os.environ["TUNE_WARN_EXCESSIVE_EXPERIMENT_CHECKPOINT_SYNC_THRESHOLD_S"] = "0"
 
+    # do not use SLURMEnvironment
+    from pytorch_lightning.plugins.environments import SLURMEnvironment
+
+    SLURMEnvironment.detect = lambda: False
+
     # needs to be run on each worker
     warnings.filterwarnings("ignore", "Checkpoint directory .* exists and is not empty")
     for module in logging.Logger.manager.loggerDict:


### PR DESCRIPTION
This PR shows the minimal changes needed to move from running tuning using CPU-only on a laptop to running using GPUs on SLURM.

1. Adds a `default_resource_request` method to the `Trainable` that specifies a non-zero GPU request. This is the only mandatory change.
2. Adds some lines to `hide_logs` specific to SLURM. This is optional; it disables Lightning's auto-resubmit feature and disables some logs by making Lightning think we aren't running on SLURM.